### PR TITLE
Add `self_link` outputs for network and router resources

### DIFF
--- a/cloud-nat/CHANGELOG.md
+++ b/cloud-nat/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [next version]
+
+### deprecations
+
+* The `subnetwork` output is deprecated in favor of the new `subnet_self_link` output.
+
+### Added
+
+* There are new `network_self_link`, `subnetwork_self_link`, and `router_self_link` outputs.

--- a/cloud-nat/main.tf
+++ b/cloud-nat/main.tf
@@ -30,7 +30,6 @@ variable "enable_flow_logs" {
   description = "whether to turn on flow logs or not"
 }
 
-
 #######################
 # Create the network and subnetworks, including secondary IP ranges on subnetworks
 #######################
@@ -55,15 +54,16 @@ resource "google_compute_subnetwork" "subnetwork" {
     range_name    = "gke-pods-1"
     ip_cidr_range = "${var.subnetwork_pods}"
   }
+
   secondary_ip_range = {
     range_name    = "gke-services-1"
     ip_cidr_range = "${var.subnetwork_services}"
   }
 
   /* We ignore changes on secondary_ip_range because terraform doesn't list
-  them in the same order every time during runs. */
+    them in the same order every time during runs. */
   lifecycle {
-    ignore_changes = [ "secondary_ip_range" ]
+    ignore_changes = ["secondary_ip_range"]
   }
 }
 
@@ -82,7 +82,7 @@ resource "google_compute_router_nat" "nat_router" {
 }
 
 /** provide outputs to be used in GKE cluster creation **/
-output "network" {
+output "network_self_link" {
   value = "${google_compute_network.network.self_link}"
 }
 
@@ -90,7 +90,11 @@ output "subnetwork" {
   value = "${google_compute_subnetwork.subnetwork.self_link}"
 }
 
-output "router" {
+output "subnetwork_self_link" {
+  value = "${google_compute_subnetwork.subnetwork.self_link}"
+}
+
+output "router_self_link" {
   value = "${google_compute_router.router.self_link}"
 }
 

--- a/cloud-nat/main.tf
+++ b/cloud-nat/main.tf
@@ -42,7 +42,7 @@ resource "google_compute_network" "network" {
 }
 
 /* note that for secondary ranges necessary for GKE Alias IPs, the ranges have
- to be manually specificied with terraform currently -- no GKE automagic allowed here. */
+ to be manually specified with terraform currently -- no GKE automagic allowed here. */
 resource "google_compute_subnetwork" "subnetwork" {
   name                     = "${var.subnetwork_name}"
   ip_cidr_range            = "${var.subnetwork_range}"
@@ -82,8 +82,16 @@ resource "google_compute_router_nat" "nat_router" {
 }
 
 /** provide outputs to be used in GKE cluster creation **/
+output "network" {
+  value = "${google_compute_network.network.self_link}"
+}
+
 output "subnetwork" {
   value = "${google_compute_subnetwork.subnetwork.self_link}"
+}
+
+output "router" {
+  value = "${google_compute_router.router.self_link}"
 }
 
 output "subnetwork_pods" {

--- a/default/CHANGELOG.md
+++ b/default/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [next version]
+
+### deprecations
+
+* The `subnetwork` output is deprecated in favor of the new `subnet_self_link` output.
+
+### Added
+
+* There are new `network_self_link` and `subnetwork_self_link` outputs.

--- a/default/main.tf
+++ b/default/main.tf
@@ -42,7 +42,7 @@ resource "google_compute_network" "network" {
 }
 
 /* note that for secondary ranges necessary for GKE Alias IPs, the ranges have
- to be manually specificied with terraform currently -- no GKE automagic allowed here. */
+ to be manually specified with terraform currently -- no GKE automagic allowed here. */
 resource "google_compute_subnetwork" "subnetwork" {
   name                     = "${var.subnetwork_name}"
   ip_cidr_range            = "${var.subnetwork_range}"
@@ -67,6 +67,10 @@ resource "google_compute_subnetwork" "subnetwork" {
   }
 }
 /** provide outputs to be used in GKE cluster creation **/
+output "network" {
+  value = "${google_compute_network.network.self_link}"
+}
+
 output "subnetwork" {
   value = "${google_compute_subnetwork.subnetwork.self_link}"
 }

--- a/default/main.tf
+++ b/default/main.tf
@@ -30,7 +30,6 @@ variable "enable_flow_logs" {
   description = "whether to turn on flow logs or not"
 }
 
-
 #######################
 # Create the network and subnetworks, including secondary IP ranges on subnetworks
 #######################
@@ -55,23 +54,29 @@ resource "google_compute_subnetwork" "subnetwork" {
     range_name    = "gke-pods-1"
     ip_cidr_range = "${var.subnetwork_pods}"
   }
+
   secondary_ip_range = {
     range_name    = "gke-services-1"
     ip_cidr_range = "${var.subnetwork_services}"
   }
 
   /* We ignore changes on secondary_ip_range because terraform doesn't list
-  them in the same order every time during runs. */
+    them in the same order every time during runs. */
   lifecycle {
-    ignore_changes = [ "secondary_ip_range" ]
+    ignore_changes = ["secondary_ip_range"]
   }
 }
+
 /** provide outputs to be used in GKE cluster creation **/
-output "network" {
+output "network_self_link" {
   value = "${google_compute_network.network.self_link}"
 }
 
 output "subnetwork" {
+  value = "${google_compute_subnetwork.subnetwork.self_link}"
+}
+
+output "subnetwork_self_link" {
   value = "${google_compute_subnetwork.subnetwork.self_link}"
 }
 


### PR DESCRIPTION
A `self_link` output for the `google_compute_network` resource is required for GCP
network peering. I've also added one for the `google_compute_router` resource.

I fixed a comment typo along the way.