### PR TITLE
adding network_description variable, bumping version to 1.0.1

### DIFF
--- a/default/CHANGELOG.md
+++ b/default/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [next version]
+## 1.0.1
 
 ### deprecations
 
@@ -13,3 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * There are new `network_self_link` and `subnetwork_self_link` outputs.
+* A network_description variable has been added, which is used as an argument to provide a description on `google_compute_network`. This is optional and defaults to null.
+
+## 1.0.0
+
+## Added
+
+* Initial release of the `default` module, which features public networking and VPC-native functionality.

--- a/default/main.tf
+++ b/default/main.tf
@@ -30,12 +30,18 @@ variable "enable_flow_logs" {
   description = "whether to turn on flow logs or not"
 }
 
+variable "network_description" {
+  default = ""
+  description = "a description for the VPC in the GCP Console"
+}
+
 #######################
 # Create the network and subnetworks, including secondary IP ranges on subnetworks
 #######################
 
 resource "google_compute_network" "network" {
   name                    = "${var.network_name}"
+  description             = "${var.description}"
   routing_mode            = "GLOBAL"
   auto_create_subnetworks = "false"
 }

--- a/default/main.tf
+++ b/default/main.tf
@@ -41,7 +41,7 @@ variable "network_description" {
 
 resource "google_compute_network" "network" {
   name                    = "${var.network_name}"
-  description             = "${var.description}"
+  description             = "${var.network_description}"
   routing_mode            = "GLOBAL"
   auto_create_subnetworks = "false"
 }


### PR DESCRIPTION
This adds a `network_description` variable to the `default` module, which is used to provide a description argument on the `google_compute_network` resource. It defaults to null, and is not a breaking change for existing implementations of this module (which all have null descriptions). 

However, by providing this, future implementations can pass `network_description` to the module to have a description placed on the network. Note that the GCP provider forces a recreation if you attempt to apply a description to an existing network, though. 

Also, bumping changelog to version 1.0.1 -- figure we should cut a patch with this and https://github.com/reactiveops/terraform-gcp-vpc-native/pull/4 